### PR TITLE
Implement CustomOp plugin system

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -45,6 +45,13 @@ Custom Operations/Nodes
 
 QONNX uses many custom operations (op_type in ONNX NodeProto) that are not defined in the ONNX operator schema. These custom nodes are marked with domain="qonnx.*" in the protobuf to identify them as such. These nodes can represent specific operations that we need for low-bit networks, or operations that are specific to a particular hardware backend. To get more familiar with custom operations and how they are created, please take a look in the Jupyter notebook about CustomOps (see chapter :ref:`tutorials` for details) or directly in the module :py:mod:`qonnx.custom_op`.
 
+Custom ops can be registered automatically via Python entry points using the
+``qonnx_custom_ops`` group. Each operator class should be decorated with
+``@register_op(domain="...", op_type="...")`` from
+``qonnx.custom_op.registry``. Packages installed with such an entry point will
+be discovered on import and their ops made available through
+``getCustomOp``.
+
 
 Custom ONNX Execution Flow
 ==========================

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,10 @@ console_scripts =
     qonnx-tensor-stats = qonnx.analysis.tensor_stats:main
 pytest_randomly.random_seeder =
     qonnx = qonnx.util.random_reseed:reseed
+# entry points for custom op modules
+qonnx_custom_ops =
+    qonnx = qonnx.custom_op.general
+    qonnx_channels_last = qonnx.custom_op.channels_last
 # Add here console scripts like:
 # console_scripts =
 #     script_name = qonnx.module:function

--- a/src/qonnx/__init__.py
+++ b/src/qonnx/__init__.py
@@ -1,0 +1,26 @@
+"""QONNX package initialization."""
+
+import warnings
+from importlib import metadata
+
+
+def _load_custom_op_entry_points():
+    """Import modules registered under the ``qonnx_custom_ops`` entry point."""
+
+    try:
+        eps = metadata.entry_points()
+        if hasattr(eps, "select"):
+            eps = eps.select(group="qonnx_custom_ops")
+        else:
+            eps = eps.get("qonnx_custom_ops", [])
+        for ep in eps:
+            try:
+                ep.load()
+            except Exception as e:  # pragma: no cover - import failure warning
+                warnings.warn(f"Failed to load custom op entry point {ep.name}: {e}")
+    except Exception as e:  # pragma: no cover - metadata failure warning
+        warnings.warn(f"Failed to query custom op entry points: {e}")
+
+
+_load_custom_op_entry_points()
+

--- a/src/qonnx/custom_op/channels_last/__init__.py
+++ b/src/qonnx/custom_op/channels_last/__init__.py
@@ -2,8 +2,4 @@ from qonnx.custom_op.channels_last.batch_normalization import BatchNormalization
 from qonnx.custom_op.channels_last.conv import Conv
 from qonnx.custom_op.channels_last.max_pool import MaxPool
 
-custom_op = dict()
-
-custom_op["Conv"] = Conv
-custom_op["MaxPool"] = MaxPool
-custom_op["BatchNormalization"] = BatchNormalization
+__all__ = ["Conv", "MaxPool", "BatchNormalization"]

--- a/src/qonnx/custom_op/channels_last/batch_normalization.py
+++ b/src/qonnx/custom_op/channels_last/batch_normalization.py
@@ -30,8 +30,10 @@ import numpy as np
 from onnx import TensorProto, helper
 
 from qonnx.custom_op.channels_last.base_wrapped_op import ChannelsLastWrappedOp
+from qonnx.custom_op.registry import register_op
 
 
+@register_op(domain="qonnx.custom_op.channels_last", op_type="BatchNormalization")
 class BatchNormalization(ChannelsLastWrappedOp):
     def get_nodeattr_types(self):
         """Returns a dict of permitted attributes for node, where:

--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -31,8 +31,10 @@ from onnx import TensorProto, helper
 
 from qonnx.custom_op.channels_last.base_wrapped_op import ChannelsLastWrappedOp
 from qonnx.custom_op.general.im2col import compute_conv_output_dim
+from qonnx.custom_op.registry import register_op
 
 
+@register_op(domain="qonnx.custom_op.channels_last", op_type="Conv")
 class Conv(ChannelsLastWrappedOp):
     def get_nodeattr_types(self):
         """Returns a dict of permitted attributes for node, where:

--- a/src/qonnx/custom_op/channels_last/max_pool.py
+++ b/src/qonnx/custom_op/channels_last/max_pool.py
@@ -30,9 +30,11 @@ import numpy as np
 from onnx import TensorProto, helper
 
 from qonnx.custom_op.channels_last.base_wrapped_op import ChannelsLastWrappedOp
+from qonnx.custom_op.registry import register_op
 from qonnx.custom_op.general.maxpoolnhwc import compute_pool_output_dim
 
 
+@register_op(domain="qonnx.custom_op.channels_last", op_type="MaxPool")
 class MaxPool(ChannelsLastWrappedOp):
     def get_nodeattr_types(self):
         """Returns a dict of permitted attributes for node, where:

--- a/src/qonnx/custom_op/general/__init__.py
+++ b/src/qonnx/custom_op/general/__init__.py
@@ -37,15 +37,15 @@ from qonnx.custom_op.general.quantavgpool2d import QuantAvgPool2d
 from qonnx.custom_op.general.trunc import Trunc
 from qonnx.custom_op.general.xnorpopcount import XnorPopcountMatMul
 
-custom_op = dict()
-
-custom_op["DebugMarker"] = DebugMarker
-custom_op["QuantAvgPool2d"] = QuantAvgPool2d
-custom_op["MaxPoolNHWC"] = MaxPoolNHWC
-custom_op["GenericPartition"] = GenericPartition
-custom_op["MultiThreshold"] = MultiThreshold
-custom_op["XnorPopcountMatMul"] = XnorPopcountMatMul
-custom_op["Im2Col"] = Im2Col
-custom_op["Quant"] = Quant
-custom_op["Trunc"] = Trunc
-custom_op["BipolarQuant"] = BipolarQuant
+__all__ = [
+    "DebugMarker",
+    "QuantAvgPool2d",
+    "MaxPoolNHWC",
+    "GenericPartition",
+    "MultiThreshold",
+    "XnorPopcountMatMul",
+    "Im2Col",
+    "Quant",
+    "Trunc",
+    "BipolarQuant",
+]

--- a/src/qonnx/custom_op/general/bipolar_quant.py
+++ b/src/qonnx/custom_op/general/bipolar_quant.py
@@ -31,6 +31,7 @@ import onnx.helper as helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
 def binary_quant(inp_tensor, scale):
@@ -47,6 +48,7 @@ def binary_quant(inp_tensor, scale):
     return out_tensor
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="BipolarQuant")
 class BipolarQuant(CustomOp):
     """Bipolar quantization operation for QONNX. Takes four inputs:
     - input tensor to quantize

--- a/src/qonnx/custom_op/general/debugmarker.py
+++ b/src/qonnx/custom_op/general/debugmarker.py
@@ -29,8 +29,10 @@
 from onnx import helper
 
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="DebugMarker")
 class DebugMarker(CustomOp):
     def get_nodeattr_types(self):
         return {"export_debug_name": ("s", True, "")}

--- a/src/qonnx/custom_op/general/genericpartition.py
+++ b/src/qonnx/custom_op/general/genericpartition.py
@@ -29,8 +29,10 @@
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.core.onnx_exec import execute_onnx
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="GenericPartition")
 class GenericPartition(CustomOp):
     """Class that corresponds to the meta/container node GenericPartition
     which is a placeholder for a group of nodes that have been separated

--- a/src/qonnx/custom_op/general/im2col.py
+++ b/src/qonnx/custom_op/general/im2col.py
@@ -31,6 +31,7 @@ import numpy as np
 import qonnx.util.basic as util
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 # adapted from A. Karpathy's CS231 im2col code
 # utilities to generate a patch matrix from a multichannel image
@@ -140,6 +141,7 @@ def im2col_indices_nchw(
 # oh/ow and kh/kw will also be 1 in this case
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="Im2Col")
 class Im2Col(CustomOp):
     def get_nodeattr_types(self):
         return {

--- a/src/qonnx/custom_op/general/maxpoolnhwc.py
+++ b/src/qonnx/custom_op/general/maxpoolnhwc.py
@@ -33,6 +33,7 @@ from onnx import TensorProto, helper
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 from qonnx.util.basic import qonnx_make_model
 
 
@@ -44,6 +45,7 @@ def compute_pool_output_dim(ifm_dim, k, stride, pad=0, ceil_mode=0):
         return int(np.floor(((ifm_dim + 2 * pad - k) / stride) + 1))
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="MaxPoolNHWC")
 class MaxPoolNHWC(CustomOp):
     # a MaxPool node, but using the NHWC data layout
 

--- a/src/qonnx/custom_op/general/multithreshold.py
+++ b/src/qonnx/custom_op/general/multithreshold.py
@@ -31,6 +31,7 @@ import onnx.helper as helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
 def multithreshold(v, thresholds, out_scale=None, out_bias=None):
@@ -84,6 +85,7 @@ def multithreshold(v, thresholds, out_scale=None, out_bias=None):
     return out_scale * ret.reshape(v.shape) + out_bias
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="MultiThreshold")
 class MultiThreshold(CustomOp):
     """Class that corresponds to a multithresholding node."""
 

--- a/src/qonnx/custom_op/general/quant.py
+++ b/src/qonnx/custom_op/general/quant.py
@@ -31,6 +31,7 @@ from onnx import TensorProto, helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
 def min_int(signed: bool, narrow_range: bool, bit_width: int) -> int:
@@ -165,6 +166,7 @@ def resolve_rounding_mode(mode_string):
         raise ValueError(f"Could not resolve rounding mode called: {normalized_mode_string}")
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="Quant")
 class Quant(CustomOp):
     """Generic quantization operation for QONNX. Takes four inputs:
     - input tensor to quantize

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -32,10 +32,12 @@ from onnx import TensorProto, helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 from qonnx.custom_op.general.maxpoolnhwc import compute_pool_output_dim
 from qonnx.util.basic import qonnx_make_model
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="QuantAvgPool2d")
 class QuantAvgPool2d(CustomOp):
     """CustomOp that corresponds to the quantized average pooling
     layer from Brevitas"""

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -31,6 +31,7 @@ import onnx.helper as helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 from qonnx.custom_op.general.quant import resolve_rounding_mode
 
 
@@ -58,6 +59,7 @@ def trunc(inp_tensor, scale, zeropt, input_bit_width, output_bit_width, rounding
     return y
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="Trunc")
 class Trunc(CustomOp):
     """Generic truncation operation for QONNX. Takes four inputs:
     - input tensor to truncate

--- a/src/qonnx/custom_op/general/xnorpopcount.py
+++ b/src/qonnx/custom_op/general/xnorpopcount.py
@@ -31,6 +31,7 @@ import onnx.helper as helper
 
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
 
 
 def xnorpopcountmatmul(inp0, inp1):
@@ -60,6 +61,7 @@ def xnorpopcountmatmul(inp0, inp1):
     return (out + K) * 0.5
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="XnorPopcountMatMul")
 class XnorPopcountMatMul(CustomOp):
     """Class that corresponds to a XNOR-popcount matrix
     multiplication node."""

--- a/src/qonnx/transformation/channels_last.py
+++ b/src/qonnx/transformation/channels_last.py
@@ -44,7 +44,8 @@ from qonnx.util.basic import get_by_name
 from qonnx.util.onnx import is_eltwise_optype
 
 # Standard ONNX nodes which require a ChannelsLast data format to function properly
-_channelsLast_node_types = list(channels_last.custom_op.keys())
+# use the list of exported op names from the channels_last package
+_channelsLast_node_types = list(channels_last.__all__)
 
 # Nodes, which do not modify the shape of the tensor
 # And modify all values in the same way.

--- a/tests/custom_op/legacy_custom_op.py
+++ b/tests/custom_op/legacy_custom_op.py
@@ -1,0 +1,21 @@
+from qonnx.custom_op.base import CustomOp
+from qonnx.custom_op.registry import register_op
+
+@register_op(domain="legacy_custom_op", op_type="LegacyAdd")
+class LegacyAdd(CustomOp):
+    def get_nodeattr_types(self):
+        return {}
+
+    def make_shape_compatible_op(self, model):
+        return super().make_const_shape_op([1])
+
+    def infer_node_datatype(self, model):
+        pass
+
+    def execute_node(self, context, graph):
+        a = context[self.onnx_node.input[0]]
+        b = context[self.onnx_node.input[1]]
+        context[self.onnx_node.output[0]] = a + b
+
+    def verify_node(self):
+        pass

--- a/tests/custom_op/test_attr.py
+++ b/tests/custom_op/test_attr.py
@@ -29,12 +29,12 @@
 import numpy as np
 import onnx.parser as oprs
 
-import qonnx.custom_op.general as general
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.base import CustomOp
-from qonnx.custom_op.registry import getCustomOp
+from qonnx.custom_op.registry import getCustomOp, register_op
 
 
+@register_op(domain="qonnx.custom_op.general", op_type="AttrTestOp")
 class AttrTestOp(CustomOp):
     def get_nodeattr_types(self):
         my_attrs = {"tensor_attr": ("t", True, np.asarray([])), "strings_attr": ("strings", True, [""])}
@@ -60,7 +60,6 @@ class AttrTestOp(CustomOp):
 
 
 def test_attr():
-    general.custom_op["AttrTestOp"] = AttrTestOp
     ishp = (1, 10)
     wshp = (1, 3)
     oshp = wshp

--- a/tests/custom_op/test_old_domain.py
+++ b/tests/custom_op/test_old_domain.py
@@ -7,7 +7,6 @@ from qonnx.util.basic import qonnx_make_model
 
 
 def test_get_custom_op_old_domain():
-    print('sys.path0', sys.path[0])
     assert "legacy_custom_op" not in sys.modules
 
     node = helper.make_node(

--- a/tests/custom_op/test_old_domain.py
+++ b/tests/custom_op/test_old_domain.py
@@ -1,0 +1,33 @@
+import sys
+from onnx import helper, TensorProto
+
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.custom_op.registry import getCustomOp
+from qonnx.util.basic import qonnx_make_model
+
+
+def test_get_custom_op_old_domain():
+    print('sys.path0', sys.path[0])
+    assert "legacy_custom_op" not in sys.modules
+
+    node = helper.make_node(
+        "LegacyAdd",
+        ["a", "b"],
+        ["c"],
+        domain="legacy_custom_op",
+    )
+
+    graph = helper.make_graph(
+        [node],
+        "legacy_graph",
+        inputs=[
+            helper.make_tensor_value_info("a", TensorProto.FLOAT, [1]),
+            helper.make_tensor_value_info("b", TensorProto.FLOAT, [1]),
+        ],
+        outputs=[helper.make_tensor_value_info("c", TensorProto.FLOAT, [1])],
+    )
+    model = qonnx_make_model(graph, producer_name="legacy-test")
+    model = ModelWrapper(model)
+
+    inst = getCustomOp(model.graph.node[0])
+    assert inst.__class__.__name__ == "LegacyAdd"


### PR DESCRIPTION
## Summary

- Introduced a registry-based plugin system in `qonnx.custom_op.registry` for registering custom ops via decorators and entry points
- Automatically load custom op modules during package initialization using `qonnx_custom_ops` entry points
- Documented the new entry point mechanism in the overview guide
- Updated built-in ops to export their names via `__all__`, enabling ChannelsLast transformation to rely on these lists
- Added a new test for legacy domain behavior and removed a leftover debug print

## Testing

✅ pytest -q tests/custom_op/test_attr.py tests/custom_op/test_old_domain.py -o addopts=''